### PR TITLE
Add explicit copy constructor for Record class

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # plogr 0.2.0 (2018-03-24)
 
-- The `PLOGR_ENABLE` macro needs to be enabled at compilation time for the library to have any effect (#3)
+- The `PLOGR_ENABLE` macro needs to be enabled at compilation time for the library to have any effect (#3).
 - In GCC builds, the function is now shown with its return type; stripping the return type failed for functions in template clases with more than one template argument.
 
 

--- a/inst/include/plog/Record.h
+++ b/inst/include/plog/Record.h
@@ -14,6 +14,12 @@ namespace plog
             util::ftime(&m_time);
         }
 
+        Record(const Record& r)
+            : m_severity(r.m_severity), m_object(r.m_object), m_line(r.m_line), m_func(r.m_func) {
+            m_message << r.getMessage();
+        }
+
+    public:
         //////////////////////////////////////////////////////////////////////////
         // Stream output operators
 


### PR DESCRIPTION
to work around oddities in clang 4.2.1 on Snow Leopard. Closes krlmlr/bindrcpp#8.