### PR TITLE
chore: Remove wchar signature for `operator<<` for C++20 compatibility

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -76,7 +76,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Update status for rcc
-        if: github.actor != 'Copilot'
+        if: github.actor != 'Copilot' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         # FIXME: Wrap into action
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -182,7 +182,7 @@ jobs:
 
       - name: Update status for rcc
         # FIXME: Wrap into action
-        if: always() && (github.actor != 'Copilot')
+        if: always() && (github.actor != 'Copilot') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/inst/include/plog/Record.h
+++ b/inst/include/plog/Record.h
@@ -30,13 +30,6 @@ namespace plog
             return *this;
         }
 
-        Record& operator<<(wchar_t data)
-        {
-            wchar_t str[] = { data, 0 };
-            *this << str;
-            return *this;
-        }
-
         template<typename T>
         Record& operator<<(const T& data)
         {


### PR DESCRIPTION
Our tooling identified this as an issue for C++20; see https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1423r3.html#proposal:

> Add deleted overloads of `basic_ostream<char, ...>::operator<<` for `wchar_t`, `char16_t` and `char32_t` character and string types and deleted overloads of `basic_ostream<wchar_t, ...>::operator<<` for `char16_t` and `char32_t` character and string types. This removes surprising behavior that has been present since C++11; that characters are formatted as numeric values and that strings are formatted as pointers.

Removing instead of attempting a fix because it doesn't work as intended anyway.

Here's the sample compilation failure we're seeing:

```
In file included from plogr/inst/include/plog/Log.h:7:
plogr/inst/include/plog/Record.h:37:23: error: overload resolution selected deleted operator '<<'
            m_message << data;
            ~~~~~~~~~ ^  ~~~~
plogr/inst/include/plog/Record.h:30:19: note: in instantiation of function template specialization 'plog::Record::operator<<<wchar_t[2]>' requested here
            *this << str;
                  ^
.../ostream:1140:31: note: candidate function [with _Traits = std::char_traits<char>] has been explicitly deleted
basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, const wchar_t*) = delete;
                              ^
.../ostream:245:20: note: candidate function
    basic_ostream& operator<<(const void* __p);
                   ^
.../ostream:233:20: note: candidate function
    basic_ostream& operator<<(bool __n);
                   ^
.../cstddef:125:3: note: candidate function template not viable: no known conversion from 'util::nstringstream' (aka 'basic_stringstream<char>') to 'byte' for 1st argument
  operator<< (byte  __lhs, _Integer __shift) noexcept
  ^
plogr/inst/include/plog/Record.h:37:23: note: remaining 51 candidates omitted; pass -fshow-overloads=all to show them
            m_message << data;
                      ^
1 error generated.
```